### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"fmt"
 
 	lio "github.com/gmcoringa/tswitch/pkg/io"
 	"github.com/gmcoringa/tswitch/pkg/lib"
@@ -138,6 +139,12 @@ func unzip(zipFile string, destination string) error {
 
 		defer fileReader.Close()
 		fpath := filepath.Join(destination, file.Name) //nolint: gosec
+		fpath = filepath.Clean(fpath)
+
+		if !strings.HasPrefix(fpath, filepath.Clean(destination)+string(os.PathSeparator)) {
+			log.Error("Invalid file path: ", fpath)
+			return fmt.Errorf("invalid file path: %s", fpath)
+		}
 
 		if file.FileInfo().IsDir() {
 			err = os.MkdirAll(fpath, os.ModePerm)


### PR DESCRIPTION
Fixes [https://github.com/gmcoringa/tswitch/security/code-scanning/1](https://github.com/gmcoringa/tswitch/security/code-scanning/1)

To fix the problem, we need to ensure that the paths extracted from the zip archive do not contain any directory traversal elements like `..`. This can be done by checking the paths before using them to create directories or files. Specifically, we should:
1. Use `filepath.Clean` to normalize the path.
2. Ensure that the resulting path is within the intended destination directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
